### PR TITLE
Updated formula to work with latest homebrew versions

### DIFF
--- a/hiberlite.rb
+++ b/hiberlite.rb
@@ -20,7 +20,7 @@ class Hiberlite < Formula
     end
   end
 
-  def pc_file; <<-EOS.undent
+  def pc_file; <<~EOS
     prefix=#{prefix}
     exec_prefix=${prefix}
     libdir=${exec_prefix}/lib
@@ -38,7 +38,7 @@ class Hiberlite < Formula
   end
 
   test do
-    (testpath/"test.cpp").write <<-EOS.undent
+    (testpath/"test.cpp").write <<~EOS
       #include "hiberlite/hiberlite.h"
       int main() {
           hiberlite::Database db("test.db");


### PR DESCRIPTION
In a recent Homebrew update (PR https://github.com/Homebrew/brew/pull/4392), `String#undent` was removed, as it has long been deprecated.
Therefore, this formula needs to be updated to work again.

According to https://github.com/Homebrew/homebrew-cask/issues/49716#issuecomment-406644285, occurrences of `<<-EOS.undent` are supposed to be replaced with `<<~EOS`.